### PR TITLE
GG FIX

### DIFF
--- a/server/UDPServerSocket.js
+++ b/server/UDPServerSocket.js
@@ -90,7 +90,7 @@ class UDPServerSocket {
                     this.logger.notice("Received unhandled packet: " + id + "(" + MessageIdentifierNames[id] + ")");
                     break;
             }
-        }else if(MessageIdentifiersNames[id] != null){
+        }else if(MessageIdentifierNames[id] != null){
             this.logger.notice("Received unhandled packet: " + id + "(" + MessageIdentifierNames[id] + ")");
         }else{
             this.logger.notice("Received unknown packet. Id: " + id);


### PR DESCRIPTION
ReferenceError: MessageIdentifiersNames is not defined
    at Socket.onmessage (/root/n/PocketNode/src/raknet/server/UDPServerSocket.js:93:18)
    at emitTwo (events.js:106:13)
    at Socket.emit (events.js:191:7)
    at UDP.onMessage (dgram.js:548:8)